### PR TITLE
Bump maximum supported sidekiq version to 6.x

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -41,4 +41,4 @@ DEPENDENCIES
   sidekiq-eventbus!
 
 BUNDLED WITH
-   1.14.6
+   2.1.4

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,18 +2,19 @@ PATH
   remote: .
   specs:
     sidekiq-eventbus (0.0.6)
-      sidekiq (>= 4.0.0, < 5.0)
+      concurrent-ruby (>= 1.0.0, < 2.0)
+      sidekiq (>= 4.0.0, < 7.0)
 
 GEM
   remote: https://rubygems.org/
   specs:
-    concurrent-ruby (1.0.4)
-    connection_pool (2.2.1)
+    concurrent-ruby (1.1.6)
+    connection_pool (2.2.2)
     diff-lcs (1.3)
-    rack (2.0.1)
-    rack-protection (1.5.3)
+    rack (2.2.2)
+    rack-protection (2.0.8.1)
       rack
-    redis (3.3.2)
+    redis (4.1.3)
     rspec (3.5.0)
       rspec-core (~> 3.5.0)
       rspec-expectations (~> 3.5.0)
@@ -27,11 +28,11 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.5.0)
     rspec-support (3.5.0)
-    sidekiq (4.2.9)
-      concurrent-ruby (~> 1.0)
-      connection_pool (~> 2.2, >= 2.2.0)
-      rack-protection (>= 1.5.0)
-      redis (~> 3.2, >= 3.2.1)
+    sidekiq (6.0.6)
+      connection_pool (>= 2.2.2)
+      rack (~> 2.0)
+      rack-protection (>= 2.0.0)
+      redis (>= 4.1.0)
 
 PLATFORMS
   ruby

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    sidekiq-eventbus (0.0.6)
+    sidekiq-eventbus (0.0.7)
       concurrent-ruby (>= 1.0.0, < 2.0)
       sidekiq (>= 4.0.0, < 7.0)
 

--- a/lib/sidekiq/event_bus/version.rb
+++ b/lib/sidekiq/event_bus/version.rb
@@ -1,5 +1,5 @@
 module Sidekiq
   module EventBus
-    VERSION = '0.0.6'
+    VERSION = '0.0.7'
   end
 end

--- a/sidekiq-eventbus.gemspec
+++ b/sidekiq-eventbus.gemspec
@@ -11,6 +11,7 @@ Gem::Specification.new do |s|
   s.homepage    = 'https://github.com/Rakefire/sidekiq-eventbus'
   s.license     = 'MIT'
 
-  s.add_dependency('sidekiq', ['>= 4.0.0', '< 5.0'])
+  s.add_dependency('concurrent-ruby', ['>= 1.0.0', '< 2.0'])
+  s.add_dependency('sidekiq', ['>= 4.0.0', '< 7.0'])
   s.add_development_dependency('rspec', ['>= 3.5.0', '< 4.0'])
 end


### PR DESCRIPTION
dependency updates:
- dependency bump: `sidekiq 6.x`
- explicitly depend on `concurrent-ruby`
- dev dependency bump: `bundler 2.1.4`